### PR TITLE
minor hotfix for dot_tsp_parser to return list[tuple[float, float]]

### DIFF
--- a/src/dataparser/dot_tsp_parser.py
+++ b/src/dataparser/dot_tsp_parser.py
@@ -18,9 +18,16 @@ def load_tsp_data(file_path: str) -> list[tuple[float, float]]:
                 if "EOF" in line or re.sub(" +", " ", line) == "\n": # in case no EOF is declared, ex: usa13509
                     break
                 if node_coord_section == True:
-                    nodes.append((re.sub(" +", " ", line).strip().split(" ")[1], re.sub(" +", " ", line).strip().split(" ")[2]))
-                if "NODE_COORD_SECTION" in line:
-                    node_coord_section = True
+                    split_line = [re.sub(" +", " ", line).strip().split(" ")[1], re.sub(" +", " ", line).strip().split(" ")[2]]
+                    for idx_split in range(2):
+                        if isinstance(split_line[idx_split], str):
+                            try:
+                                split_line[idx_split] = float(split_line[idx_split])
+                            except ValueError:
+                                split_line[idx_split] = int(split_line[idx_split])
+                    nodes.append(tuple(split_line))
+                else:
+                    node_coord_section = "NODE_COORD_SECTION" in line
             except IndexError:
                 break
     if nodes == []:

--- a/tests/unit/dataparser/test_dot_tsp_parser.py
+++ b/tests/unit/dataparser/test_dot_tsp_parser.py
@@ -30,7 +30,7 @@ def test_load_tsp_data_no_eof(tmp_path):
     path = tmp_path / "no_eof.tsp"
     path.write_text(content)
     result = load_tsp_data(str(path))
-    assert result == [("10", "20"), ("30", "40"), ("50", "60")]
+    assert result == [(10, 20), (30, 40), (50, 60)]
 
 def test_load_tsp_data_valid_file(tmp_path):
     content = (
@@ -45,7 +45,7 @@ def test_load_tsp_data_valid_file(tmp_path):
     path = tmp_path / "valid.tsp"
     path.write_text(content)
     result = load_tsp_data(str(path))
-    assert result == [("10", "20"), ("30", "40"), ("50", "60")]
+    assert result == [(10, 20), (30, 40), (50, 60)]
 
 def test_load_tsp_data_no_node_section(tmp_path):
     content = (
@@ -71,4 +71,4 @@ def test_load_tsp_data_irregular_spacing(tmp_path):
     path = tmp_path / "irregular_spacing.tsp"
     path.write_text(content)
     result = load_tsp_data(str(path))
-    assert result == [("10", "20"), ("30", "40"), ("50", "60")]
+    assert result == [(10, 20), (30, 40), (50, 60)]


### PR DESCRIPTION
fixed dot_tsp_parser to convert to list[tuple[float, float]] instead of list[tuple[str, str]]